### PR TITLE
Disable spellcheck for raw TeX input

### DIFF
--- a/src/math-nodeview.ts
+++ b/src/math-nodeview.ts
@@ -99,6 +99,7 @@ export class MathView implements NodeView, ICursorPosObserver {
 
 		this._mathSrcElt = document.createElement("span");
 		this._mathSrcElt.classList.add("math-src");
+		this._mathSrcElt.spellcheck = false;
 		this.dom.appendChild(this._mathSrcElt);
 
 		// ensure 


### PR DESCRIPTION
`prosemirror-math` demo has spellcheck [disabled](https://github.com/benrbray/prosemirror-math/blob/master/docs-src/index.html#L38) for the whole editor, but in real-life cases spell checking is often necessary. But it doesn't make sense to spellcheck raw TeX, therefore this PR disables that.